### PR TITLE
Convert SRMR from function to class

### DIFF
--- a/srmrpy/__init__.py
+++ b/srmrpy/__init__.py
@@ -4,4 +4,4 @@
 # This file is part of the SRMRpy library, and is licensed under the
 # MIT license: https://github.com/jfsantos/SRMRpy/blob/master/LICENSE
 
-from srmrpy.srmr import srmr
+from srmrpy.srmr import SRMR

--- a/test/test_srmr.py
+++ b/test/test_srmr.py
@@ -4,7 +4,7 @@
 # This file is part of the SRMRpy library, and is licensed under the
 # MIT license: https://github.com/jfsantos/SRMRpy/blob/master/LICENSE
 
-from srmrpy import srmr
+from srmrpy import SRMR
 from scipy.io.matlab import loadmat
 import numpy as np
 
@@ -13,17 +13,44 @@ def test_srmr():
     s = loadmat("test/test.mat")["s"][:,0]
 
     correct_ratios = loadmat("test/correct_ratios.mat")['correct_ratios'][0]
-    ratio, avg_energy = srmr(s, fs)
+    srmr = SRMR(fs)
+    out = srmr.predict(s, s, s)
+    ratio, avg_energy = out['p']['srmr'], out['avg_energy']
     assert np.allclose(ratio, correct_ratios[1], rtol=1e-6, atol=1e-12)
 
-    ratio_norm_fast, avg_energy_norm_fast = srmr(s, fs, fast=True, norm=True, max_cf=30)
+def test_srmr_norm_fast():
+    fs = 16000
+    s = loadmat("test/test.mat")["s"][:,0]
+
+    correct_ratios = loadmat("test/correct_ratios.mat")['correct_ratios'][0]
+    srmr = SRMR(fs, fast=True, norm=True, max_cf=30)
+    out = srmr.predict(s, s, s)
+    ratio_norm_fast, avg_energy_norm_fast = out['p']['srmr'], \
+                                          out['avg_energy']
     assert np.allclose(ratio_norm_fast, correct_ratios[2], rtol=1e-6, atol=1e-12)
 
-    ratio_slow, avg_energy_slow = srmr(s, fs, fast=False)
+def test_srmr_slow():
+    fs = 16000
+    s = loadmat("test/test.mat")["s"][:,0]
+
+    correct_ratios = loadmat("test/correct_ratios.mat")['correct_ratios'][0]
+    srmr = SRMR(fs, fast=False)
+    out = srmr.predict(s, s, s)
+    ratio_slow, avg_energy_slow = out['p']['srmr'], out['avg_energy']
     assert np.allclose(ratio_slow, correct_ratios[0], rtol=1e-6, atol=1e-12)
 
-    ratio_norm, avg_energy_norm = srmr(s, fs, fast=False, norm=True, max_cf=30)
+def test_srmr_norm():
+    fs = 16000
+    s = loadmat("test/test.mat")["s"][:,0]
+
+    correct_ratios = loadmat("test/correct_ratios.mat")['correct_ratios'][0]
+    srmr = SRMR(fs, fast=False, norm=True, max_cf=30)
+    out = srmr.predict(s, s, s)
+    ratio_norm, avg_energy_norm = out['p']['srmr'], out['avg_energy']
     assert np.allclose(ratio_norm, correct_ratios[3], rtol=1e-6, atol=1e-12)
 
 if __name__ == '__main__':
     test_srmr()
+    test_srmr_norm()
+    test_srmr_norm_fast()
+    test_srmr_slow()


### PR DESCRIPTION
I took the liberty to do the refactoring into a class that is consistent with
the structure of the other intelligibility models in PAMBOX. The class
has a `predict` method that takes the clean, mixture, and noise only. 
In this case, only the mixture is used.

The tests are also modified to use the new structure.

The `calc_erbs` and `calc_cutoffs` could possibly also be converted to
regular methods, instead of static methods.

There would also be some refactoring to do for the modulation filterbank
code, but this is a start.
