### PR TITLE
Fix deprecation

### DIFF
--- a/srmrpy/hilbert.py
+++ b/srmrpy/hilbert.py
@@ -66,7 +66,7 @@ def hilbert(x, N=None, axis=-1):
     if len(x.shape) > 1:
         ind = [newaxis] * x.ndim
         ind[axis] = slice(None)
-        h = h[ind]
+        h = h[tuple(ind)]
     y = ifft(Xf * h, axis=axis)
     return y[:x.shape[axis]]
 


### PR DESCRIPTION
Fixes: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.