### PR TITLE
fix error in newer numpy

### DIFF
--- a/srmrpy/modulation_filters.py
+++ b/srmrpy/modulation_filters.py
@@ -11,8 +11,8 @@ import scipy.signal as sig
 def make_modulation_filter(w0, Q):
     W0 = np.tan(w0/2)
     B0 = W0/Q
-    b = np.array([B0, 0, -B0], dtype=np.float)
-    a = np.array([(1 + B0 + W0**2), (2*W0**2 - 2), (1 - B0 + W0**2)], dtype=np.float)
+    b = np.array([B0, 0, -B0], dtype=np.float64)
+    a = np.array([(1 + B0 + W0**2), (2*W0**2 - 2), (1 - B0 + W0**2)], dtype=np.float64)
     return b, a
 
 def modulation_filterbank(mf, fs, Q):
@@ -27,7 +27,7 @@ def compute_modulation_cfs(min_cf, max_cf, n):
     return cfs
 
 def modfilt(F, x):
-    y = np.zeros((len(F), len(x)), dtype=np.float)
+    y = np.zeros((len(F), len(x)), dtype=np.float64)
     for k, f in enumerate(F):
         y[k] = sig.lfilter(f[0], f[1], x)
     return y


### PR DESCRIPTION
fix the error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data/home/x/miniconda3/lib/python3.9/site-packages/srmrpy/srmr.py", line 59, in srmr
    MF = modulation_filterbank(mod_filter_cfs, mfs, 2)
  File "/data/home/x/miniconda3/lib/python3.9/site-packages/srmrpy/modulation_filters.py", line 19, in modulation_filterbank
    return [make_modulation_filter(w0, Q) for w0 in 2*np.pi*mf/fs]
  File "/data/home/x/miniconda3/lib/python3.9/site-packages/srmrpy/modulation_filters.py", line 19, in <listcomp>
    return [make_modulation_filter(w0, Q) for w0 in 2*np.pi*mf/fs]
  File "/data/home/x/miniconda3/lib/python3.9/site-packages/srmrpy/modulation_filters.py", line 14, in make_modulation_filter
    b = np.array([B0, 0, -B0], dtype=np.float)
  File "/data/home/x/miniconda3/lib/python3.9/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
```