### PR TITLE
change gammatone requirement to `Gammatone`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires = [
         'numpy',
         'scipy',
-        'gammatone @ git+https://github.com/detly/gammatone',
+        'Gammatone',
     ],
 
     tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires = [
         'numpy',
         'scipy',
-        'Gammatone @ https://github.com/detly/gammatone/archive/master.zip#egg=Gammatone',
+        'gammatone @ git+https://github.com/detly/gammatone',
     ],
 
     tests_require = [


### PR DESCRIPTION
Hello, `Torchmetrics` requires `SRMRpy` for validating its implementations. However, `SRMRpy` install `Gammatone` by `https://github.com/detly/gammatone/archive/master.zip#egg=Gammatone` which will be skipped for pypi. So, this pull request change it to `git+https://github.com/detly/gammatone`, which will not affect the installtion of `SRMRpy`, but will make the requirements in `Torchmetrics` works. see the discussion here https://github.com/Lightning-AI/torchmetrics/pull/1792#discussion_r1224587214